### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/essentia/security/code-scanning/2](https://github.com/xdoubleu/essentia/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not perform any actions requiring write permissions, we can set the permissions to `contents: read` at the root level. This will apply to all jobs in the workflow unless overridden by job-specific permissions. This change ensures that the workflow adheres to the principle of least privilege while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
