### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: lint & test workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/essentia/security/code-scanning/1](https://github.com/xdoubleu/essentia/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient, as the workflow only interacts with repository contents (e.g., checking out code and running tests). No write permissions are necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different permissions are required for each job. In this case, a root-level `permissions` block is appropriate since all jobs in the workflow only require `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
